### PR TITLE
Ensure merged PDF is closed properly

### DIFF
--- a/backend/merge.py
+++ b/backend/merge.py
@@ -1,12 +1,25 @@
-import sys, json, pikepdf
+import sys
+import json
+import pikepdf
+
+
 def merge_pdfs(paths_json, out_path):
     try:
         paths = json.loads(paths_json)
-        if len(paths) < 2: return {"success": False, "message": "Select at least two PDFs."}
-        pdf = pikepdf.Pdf.new()
-        for file in paths:
-            with pikepdf.Pdf.open(file) as src: pdf.pages.extend(src.pages)
-        pdf.save(out_path)
-        return {"success": True, "message": f"Successfully merged {len(paths)} files!"}
-    except Exception as e: return {"success": False, "message": f"Error: {e}"}
-if __name__ == "__main__": print(json.dumps(merge_pdfs(sys.argv[1], sys.argv[2])))
+        if len(paths) < 2:
+            return {"success": False, "message": "Select at least two PDFs."}
+        with pikepdf.Pdf.new() as pdf:
+            for file in paths:
+                with pikepdf.Pdf.open(file) as src:
+                    pdf.pages.extend(src.pages)
+            pdf.save(out_path)
+        return {
+            "success": True,
+            "message": f"Successfully merged {len(paths)} files!",
+        }
+    except Exception as e:
+        return {"success": False, "message": f"Error: {e}"}
+
+
+if __name__ == "__main__":
+    print(json.dumps(merge_pdfs(sys.argv[1], sys.argv[2])))


### PR DESCRIPTION
## Summary
- manage output PDF with a context manager in backend merge routine to ensure the file is closed after saving

## Testing
- `python -m py_compile backend/merge.py`
- `python - <<'PY'
import pikepdf, json
from backend.merge import merge_pdfs

# create dummy pdfs with a blank page each
with pikepdf.Pdf.new() as pdf:
    pdf.add_blank_page()
    pdf.save('test1.pdf')
with pikepdf.Pdf.new() as pdf:
    pdf.add_blank_page()
    pdf.save('test2.pdf')

result = merge_pdfs(json.dumps(['test1.pdf', 'test2.pdf']), 'out.pdf')
print(result)
with pikepdf.Pdf.open('out.pdf') as merged:
    print('merged pages:', len(merged.pages))
PY`

------
https://chatgpt.com/codex/tasks/task_e_688f13250dc88333987277f8e9c428ac