### PR TITLE
Fetch update info from URL and parse semantic versions

### DIFF
--- a/backend/notify.py
+++ b/backend/notify.py
@@ -1,15 +1,36 @@
 import sys, json, urllib.request
+from packaging.version import Version, InvalidVersion
+
 CURRENT_VERSION = "1.0.0"
+
+
 def check_for_updates(url):
-    try:
-        # In a real app, replace local file read with urlopen
-        # with urllib.request.urlopen(url) as response:
-        #    data = json.loads(response.read().decode())
-        with open("../config/update.json", "r") as f:
-            data = json.load(f)
-        latest = data.get("latestVersion")
-        if latest and latest > CURRENT_VERSION:
-            return {"isNewVersion": True, "latestVersion": latest, "message": data.get("message"), "downloadUrl": data.get("downloadUrl")}
+    if not url:
         return {"isNewVersion": False}
-    except Exception: return {"isNewVersion": False}
-if __name__ == "__main__": print(json.dumps(check_for_updates(sys.argv[1])))
+    try:
+        with urllib.request.urlopen(url) as response:
+            data = json.loads(response.read().decode())
+    except Exception:
+        return {"isNewVersion": False}
+
+    latest = data.get("latestVersion")
+    if not latest:
+        return {"isNewVersion": False}
+
+    try:
+        if Version(latest) > Version(CURRENT_VERSION):
+            return {
+                "isNewVersion": True,
+                "latestVersion": latest,
+                "message": data.get("message"),
+                "downloadUrl": data.get("downloadUrl"),
+            }
+    except InvalidVersion:
+        pass
+
+    return {"isNewVersion": False}
+
+
+if __name__ == "__main__":
+    url_arg = sys.argv[1] if len(sys.argv) > 1 else ""
+    print(json.dumps(check_for_updates(url_arg)))


### PR DESCRIPTION
## Summary
- Request update metadata from the provided URL using `urllib.request.urlopen`
- Compare semantic versions via `packaging.Version` and handle missing or invalid configuration gracefully

## Testing
- `python -m py_compile backend/notify.py`
- `python backend/notify.py file:config/update.json`


------
https://chatgpt.com/codex/tasks/task_e_688f1327841c8333a884ffb206f2adcb