### PR TITLE
Add Python requirements and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# ForgePDF Dojo
+
+## Installation
+
+Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyMuPDF
+pikepdf
+packaging


### PR DESCRIPTION
## Summary
- Add requirements.txt listing PyMuPDF, pikepdf and packaging
- Document Python dependency installation in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile backend/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f275dcc6083338d8256a4c32fc2d6