### PR TITLE
chore: ignore Python bytecode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ yarn-error.log*
 
 # System files
 .DS_Store
+
+# Python bytecode
+__pycache__/
+*.pyc
+*.pyo


### PR DESCRIPTION
## Summary
- ignore Python bytecode in git

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f27604c5c8333abbb86a7940f097a