### PR TITLE
Handle invalid Python script output

### DIFF
--- a/main.js
+++ b/main.js
@@ -100,8 +100,17 @@ async function runPythonScript(scriptName, args) {
         scriptPath: scriptFolder,
         args: args,
     };
+    console.log(`Executing ${scriptName} with args:`, args);
     try {
         const results = await PythonShell.run(scriptName, options);
+        console.log(`Raw results from ${scriptName}:`, results);
+
+        if (!Array.isArray(results) || results.length === 0 || results[0] === undefined) {
+            const message = `Invalid response from ${scriptName}. Expected a JSON array with at least one item.`;
+            console.error(message, results);
+            return { success: false, message };
+        }
+
         return results[0];
     } catch (err) {
         console.error(`Error running ${scriptName}:`, err);


### PR DESCRIPTION
## Summary
- add detailed console logging for Python script execution
- validate PythonShell results and return descriptive errors when invalid

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_688f276181f8833384a7facb76b7c8b5