### PR TITLE
Handle update check timeouts

### DIFF
--- a/backend/notify.py
+++ b/backend/notify.py
@@ -1,15 +1,18 @@
-import sys, json, urllib.request
+import sys, json, urllib.request, socket, logging
 from packaging.version import Version, InvalidVersion
 
 CURRENT_VERSION = "1.0.0"
 
 
-def check_for_updates(url):
+def check_for_updates(url, timeout=5):
     if not url:
         return {"isNewVersion": False}
     try:
-        with urllib.request.urlopen(url) as response:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
             data = json.loads(response.read().decode())
+    except socket.timeout:
+        logging.warning("Timeout checking for updates", exc_info=True)
+        return {"isNewVersion": False}
     except Exception:
         return {"isNewVersion": False}
 
@@ -33,4 +36,5 @@ def check_for_updates(url):
 
 if __name__ == "__main__":
     url_arg = sys.argv[1] if len(sys.argv) > 1 else ""
-    print(json.dumps(check_for_updates(url_arg)))
+    timeout_arg = int(sys.argv[2]) if len(sys.argv) > 2 else 5
+    print(json.dumps(check_for_updates(url_arg, timeout=timeout_arg)))


### PR DESCRIPTION
## Summary
- add configurable timeout to update checker
- log timeout and return no-update indicator on socket timeout

## Testing
- `python -m py_compile backend/notify.py`
- `python backend/notify.py http://10.255.255.1 1`


------
https://chatgpt.com/codex/tasks/task_e_688f276cb3748333963bb45325854405