### PR TITLE
Pass app version to update checker

### DIFF
--- a/backend/notify.py
+++ b/backend/notify.py
@@ -1,11 +1,9 @@
 import sys, json, urllib.request
 from packaging.version import Version, InvalidVersion
 
-CURRENT_VERSION = "1.0.0"
 
-
-def check_for_updates(url):
-    if not url:
+def check_for_updates(url, current_version):
+    if not url or not current_version:
         return {"isNewVersion": False}
     try:
         with urllib.request.urlopen(url) as response:
@@ -18,7 +16,7 @@ def check_for_updates(url):
         return {"isNewVersion": False}
 
     try:
-        if Version(latest) > Version(CURRENT_VERSION):
+        if Version(latest) > Version(current_version):
             return {
                 "isNewVersion": True,
                 "latestVersion": latest,
@@ -33,4 +31,5 @@ def check_for_updates(url):
 
 if __name__ == "__main__":
     url_arg = sys.argv[1] if len(sys.argv) > 1 else ""
-    print(json.dumps(check_for_updates(url_arg)))
+    version_arg = sys.argv[2] if len(sys.argv) > 2 else ""
+    print(json.dumps(check_for_updates(url_arg, version_arg)))

--- a/main.js
+++ b/main.js
@@ -138,7 +138,9 @@ ipcMain.handle('pdf:watermark', async (event, filePath, options) => {
 
 ipcMain.handle('app:check-update', async () => {
     const updateUrl = 'https://your-domain.com/path/to/update.json';
-    return await runPythonScript('notify.py', [updateUrl]);
+    // Pass the current app version so the Python script can compare properly
+    const currentVersion = app.getVersion();
+    return await runPythonScript('notify.py', [updateUrl, currentVersion]);
 });
 
 module.exports = { getPythonPath, runPythonScript };


### PR DESCRIPTION
## Summary
- Pass Electron app version to Python notify script when checking for updates
- Remove hard-coded version in notify.py and read version from command line

## Testing
- `python -m py_compile backend/notify.py`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f276eae808333a3288ab1f70a148a