### PR TITLE
Make update URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# ForgePDF Dojo
+
+A portable desktop PDF utility built with Electron and Python.
+
+## Update Configuration
+
+The application checks for updates by downloading a small `update.json` file.
+Set the location of this file in `config/settings.json` using the `updateUrl` field.
+
+Maintainers should host `update.json` at a publicly accessible HTTPS endpoint
+(such as a web server or GitHub Pages) and point `updateUrl` to that address.
+The `config/update.json` file in this repository serves as an example of the
+expected format.
+

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,3 +1,4 @@
 {
-  "pythonPath": ""
+  "pythonPath": "",
+  "updateUrl": "https://example.com/update.json"
 }


### PR DESCRIPTION
## Summary
- allow update endpoint to be configured via `config/settings.json`
- add configuration docs for maintainers and example URL

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f277662b08333a028b7ef379a8d09