### PR TITLE
docs: add project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# ForgePDF Dojo
+
+ForgePDF Dojo is a cross-platform desktop utility built with Electron and Python for performing common PDF tasks such as merging, compressing, watermarking and password protecting files.
+
+## Setup
+
+### Prerequisites
+- **Node.js** and **npm**
+- **Python 3**
+
+### Node dependencies
+Install JavaScript dependencies from the project root:
+
+```bash
+npm install
+```
+
+### Python dependencies
+Install the required Python packages:
+
+```bash
+pip install pikepdf pymupdf packaging
+```
+
+## Build Commands
+
+- `npm start` – Run the application in development.
+- `npm run pack` – Create an unpacked build.
+- `npm run dist` – Generate a distributable package.
+
+## Usage
+
+After installing dependencies, launch the app with `npm start` and use the interface to choose actions like merge, compress or watermark PDFs.
+
+## Contributing
+
+1. Fork the repository and create your feature branch.
+2. Commit your changes with clear messages.
+3. Open a pull request and describe your modifications.
+
+Please ensure your contributions adhere to existing code style and run available checks before submitting.
+
+## License
+
+This project is released under the MIT License.
+


### PR DESCRIPTION
## Summary
- document project purpose, setup, build commands, and usage
- note contribution guidelines and MIT license

## Testing
- `npm test` *(fails: Missing script "test")*
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688f277f44a08333a3a4a46919b31fe3