### PR TITLE
Add pytest tests for PDF utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ yarn-error.log*
 
 # System files
 .DS_Store
+
+# Python
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# ForgePDF Dojo
+
+Utilities for working with PDFs.
+
+## Running tests
+
+This project uses [pytest](https://pytest.org) to test the backend scripts such as `compress_pdf`, `merge_pdfs`, `protect_pdf`, and `add_watermark`.
+
+Install the Python dependencies and run the test suite:
+
+```bash
+pip install pikepdf PyMuPDF pytest
+pytest
+```
+

--- a/backend/watermark.py
+++ b/backend/watermark.py
@@ -47,8 +47,7 @@ def add_watermark(input_path, output_path, options_json):
             tw.append(start_pos, text, font=font, fontsize=font_size)
             
             # 7. Write the text to the page, applying the final transformation matrix
-            # This is the key step for older library versions
-            tw.write_text(page, transform=mat)
+            tw.write_text(page, matrix=mat)
 
         doc.save(output_path)
         doc.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+import pytest
+import fitz
+
+# Ensure backend modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'backend'))
+
+@pytest.fixture
+def make_pdf(tmp_path):
+    def _make_pdf(name="sample.pdf", text="Hello"):
+        path = tmp_path / name
+        doc = fitz.open()
+        page = doc.new_page()
+        page.insert_text((72, 72), text)
+        doc.save(path)
+        return path
+    return _make_pdf

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -1,0 +1,10 @@
+import os
+from compress import compress_pdf
+
+def test_compress_pdf(make_pdf, tmp_path):
+    input_pdf = make_pdf("in.pdf", "hello" * 100)
+    output_pdf = tmp_path / "out.pdf"
+    result = compress_pdf(str(input_pdf), str(output_pdf))
+    assert result["success"]
+    assert output_pdf.exists()
+    assert os.path.getsize(output_pdf) <= os.path.getsize(input_pdf)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,13 @@
+import json
+import fitz
+from merge import merge_pdfs
+
+def test_merge_pdfs(make_pdf, tmp_path):
+    pdf1 = make_pdf("a.pdf", "A")
+    pdf2 = make_pdf("b.pdf", "B")
+    output_pdf = tmp_path / "merged.pdf"
+    result = merge_pdfs(json.dumps([str(pdf1), str(pdf2)]), str(output_pdf))
+    assert result["success"]
+    assert output_pdf.exists()
+    with fitz.open(output_pdf) as doc:
+        assert len(doc) == 2

--- a/tests/test_protect.py
+++ b/tests/test_protect.py
@@ -1,0 +1,16 @@
+import pytest
+import pikepdf
+from protect import protect_pdf
+
+
+def test_protect_pdf(make_pdf, tmp_path):
+    input_pdf = make_pdf("in.pdf")
+    output_pdf = tmp_path / "protected.pdf"
+    password = "secret"
+    result = protect_pdf(str(input_pdf), str(output_pdf), password)
+    assert result["success"]
+    assert output_pdf.exists()
+    with pytest.raises(pikepdf.PasswordError):
+        pikepdf.Pdf.open(output_pdf)
+    with pikepdf.Pdf.open(output_pdf, password=password) as pdf:
+        assert len(pdf.pages) == 1

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -1,0 +1,13 @@
+import os
+import json
+from watermark import add_watermark
+
+
+def test_add_watermark(make_pdf, tmp_path):
+    input_pdf = make_pdf("in.pdf")
+    output_pdf = tmp_path / "watermarked.pdf"
+    options = json.dumps({"text": "TEST"})
+    result = add_watermark(str(input_pdf), str(output_pdf), options)
+    assert result["success"]
+    assert output_pdf.exists()
+    assert os.path.getsize(output_pdf) > os.path.getsize(input_pdf)


### PR DESCRIPTION
## Summary
- add pytest suite for compress, merge, protect and watermark scripts
- fix watermark script to use `matrix` argument in PyMuPDF
- document running tests with `pytest`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f2792d60c83338b34c7fd3ab3acb6