### PR TITLE
chore: remove deprecated watermarking

### DIFF
--- a/main.js
+++ b/main.js
@@ -130,13 +130,6 @@ ipcMain.handle('pdf:protect', async (event, filePath, password) => {
     return await runPythonScript('protect.py', [filePath, outputPath, password]);
 });
 
-// ipcMain.handle('pdf:watermark', async (event, filePath, options) => {
-//     const defaultPath = filePath.replace('.pdf', '-watermarked.pdf');
-//     const { filePath: outputPath, canceled } = await dialog.showSaveDialog({ title: 'Save Watermarked PDF', buttonLabel: 'Save', defaultPath: defaultPath, filters: [{ name: 'PDFs', extensions: ['pdf'] }] });
-//     if (canceled || !outputPath) return { success: false, message: 'Save operation canceled.' };
-//     return await runPythonScript('watermark.py', [filePath, outputPath, JSON.stringify(options)]);
-// });
-
 ipcMain.handle('app:check-update', async () => {
     const updateUrl = 'https://your-domain.com/path/to/update.json';
     return await runPythonScript('notify.py', [updateUrl]);

--- a/preload.js
+++ b/preload.js
@@ -4,7 +4,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     mergePDFs: (filePaths) => ipcRenderer.invoke('pdf:merge', filePaths),
     compressPDF: (filePath) => ipcRenderer.invoke('pdf:compress', filePath),
     protectPDF: (filePath, password) => ipcRenderer.invoke('pdf:protect', filePath, password),
-    watermarkPDF: (filePath, options) => ipcRenderer.invoke('pdf:watermark', filePath, options),
     checkForUpdate: () => ipcRenderer.invoke('app:check-update'),
     on: (channel, callback) => {
         const validChannels = ['update-notification'];


### PR DESCRIPTION
## Summary
- remove deprecated `watermarkPDF` API from preload
- drop leftover watermark handler comments in main process

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f2c29f7e08333a86f8891ac8c5c48