### PR TITLE
Pin core PDF dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ Install Python dependencies:
 pip install -r requirements.txt
 ```
 
+The pinned requirements ensure a reproducible environment:
+
+- PyMuPDF 1.26.3
+- pikepdf 9.10.2
+- packaging 25.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyMuPDF
-pikepdf
-packaging
+PyMuPDF==1.26.3
+pikepdf==9.10.2
+packaging==25.0


### PR DESCRIPTION
## Summary
- pin PyMuPDF, pikepdf, and packaging versions for reproducible builds
- document pinned Python dependencies in README

## Testing
- `python -m py_compile backend/*.py`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688f2c33e9a083338e8a280bf4342488